### PR TITLE
Add a new variable to choose the cgroup driver

### DIFF
--- a/modules/aws-k8s-conformance/master.tf
+++ b/modules/aws-k8s-conformance/master.tf
@@ -35,6 +35,7 @@ data "template_file" "init_master" {
     public_ip          = aws_eip.master.public_ip
     join_token         = "${random_string.firts_part.result}.${random_string.second_part.result}"
     pod_network_cidr   = var.pod_network_cidr
+    cgroupdriver       = var.cgroupdriver
   }
 }
 

--- a/modules/aws-k8s-conformance/templates/master.tpl.yaml
+++ b/modules/aws-k8s-conformance/templates/master.tpl.yaml
@@ -15,7 +15,8 @@ write_files:
             "max-size": "10m",
             "max-file": "5"
           },
-          "storage-driver": "overlay2"
+          "storage-driver": "overlay2",
+          "exec-opts": ["native.cgroupdriver=${cgroupdriver}"]
         }
     path: /etc/docker/daemon.json
 users:

--- a/modules/aws-k8s-conformance/templates/worker.tpl.yaml
+++ b/modules/aws-k8s-conformance/templates/worker.tpl.yaml
@@ -19,7 +19,8 @@ write_files:
             "max-size": "10m",
             "max-file": "5"
           },
-          "storage-driver": "overlay2"
+          "storage-driver": "overlay2",
+          "exec-opts": ["native.cgroupdriver=${cgroupdriver}"]
         }
     path: /etc/docker/daemon.json
 users:

--- a/modules/aws-k8s-conformance/variables.tf
+++ b/modules/aws-k8s-conformance/variables.tf
@@ -53,6 +53,12 @@ variable "pod_network_cidr" {
   default     = "192.168.0.0/16"
 }
 
+variable "cgroupdriver" {
+  type        = string
+  description = "cgroup driver for docker. Choose cgroupfs or systemd"
+  default     = "cgroupfs"
+}
+
 locals {
   # https://cloud-images.ubuntu.com/locator/ec2/
   # filter: 18.04 LTS eu- ebs-ssd 2020

--- a/modules/aws-k8s-conformance/workers.tf
+++ b/modules/aws-k8s-conformance/workers.tf
@@ -40,6 +40,7 @@ data "template_file" "init_worker" {
     master_private_ip  = aws_spot_instance_request.master.private_ip
     join_token         = "${random_string.firts_part.result}.${random_string.second_part.result}"
     wait_for_script    = indent(8, file("${path.module}/resources/wait-for.sh"))
+    cgroupdriver       = var.cgroupdriver
   }
 }
 


### PR DESCRIPTION
Ciao @nandajavarma!

This PR contains a new (optional) variable to the k8s module. This is needed because starting from Kubernetes 1.22, the default kubelet cgroup driver becomes systemd, then docker daemon requires to set the `systemd` cgroup driver.

So, if you have plans to spin up a Kubernetes >=1.22 (like the following example):

```
module "fury" {
  source = "../../modules/aws-k8s-conformance"

  region = data.aws_region.current.name

  cluster_name    = "fury"
  cluster_version = "1.22.0"

  worker_instance_type = "m4.xlarge"
  master_instance_type = "m4.xlarge"
  worker_count         = 3

  public_subnet_id  = "subnet-ec0066b6"
  private_subnet_id = "subnet-3253677a"
  pod_network_cidr  = "172.16.0.0/16"
  
  cgroupdriver = "systemd"
}
```

Don't forget to add the **`cgroupdriver = "systemd"`**. Its default value is `cgroupfs`.

Thanks!